### PR TITLE
changed write to write_all in watchdog.rs #34

### DIFF
--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -27,7 +27,7 @@ impl Watchdog {
 		if let Some(handle) = &mut self.handle {
 			self.wait_for_watchdog_trigger += 1;
 			if self.wait_for_watchdog_trigger > 1000 {
-				handle.write(b"a").expect("could not write to watchdog");
+				handle.write_all(b"a").expect("could not write to watchdog");
 				self.wait_for_watchdog_trigger = 0;
 			}
 		}


### PR DESCRIPTION
This pull request gets rid of the `cargo clippy` error from #34 .